### PR TITLE
implement support for multi-line strings, for preference value

### DIFF
--- a/Preferences.py
+++ b/Preferences.py
@@ -33,6 +33,13 @@ This example shows how to use pypref.
         # especial characters. That's how to do it ...
         pref.update_preferences({'my path': " r'C:\\Users\\Me\\Desktop' "})
 
+        # multi-line strings can also be used as values
+        multiline=\"\"\"this is a
+        multi-line
+        value
+        \"\"\"
+        pref.set_preferences({'preference 2', multiline})
+
         # Sometimes preferences to change dynamically or to be evaluated real time.
         # This also can be done by using dynamic property. In this example password
         # generator preference is set using uuid module. dynamic dictionary
@@ -241,7 +248,9 @@ A valid filename must not contain especial characters or operating system separa
         stripped = s.strip()
         if not stripped.startswith('"') and not stripped.endswith('"'):
             if not stripped.startswith("'") and not stripped.endswith("'"):
-                if "'" in s:
+                if s.find('\n')>=0: # we have a multi-line string
+                    s = '"""%s"""'%s
+                elif "'" in s:
                     s = '"%s"'%s
                 else:
                     s = "'%s'"%s

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+import sys
+import tempfile
+
+# for Python 3.2+, there is a TemporaryDirectory class defined
+# a class substitute is proposed for lower versions.
+
+if sys.version_info>(3,2):
+    from tempfile import TemporaryDirectory
+else:
+    import shutil
+
+    class TemporaryDirectory:
+        def __init__(self):
+            self.name = tempfile.mkdtemp()
+
+        def cleanup(self):
+            if self.name:
+                shutil.rmtree(self.name)
+                self.name = None
+
+        def __del__(self):
+            self.cleanup()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -6,7 +6,7 @@ import tempfile
 # for Python 3.2+, there is a TemporaryDirectory class defined
 # a class substitute is proposed for lower versions.
 
-if sys.version_info>(3,2):
+if sys.version_info>=(3,2):
     from tempfile import TemporaryDirectory
 else:
     import shutil

--- a/tests/test_loadpref.py
+++ b/tests/test_loadpref.py
@@ -1,16 +1,18 @@
+# -*- coding: utf-8 -*-
+
 import unittest
-import tempfile
-from pypref import SinglePreferences as Preferences
+from pypref import Preferences
+from .fixtures import TemporaryDirectory
 
 class TestPreferencesMethods(unittest.TestCase):
 
     def setUp(self):
-        self.d = tempfile.TemporaryDirectory()
+        self.d = TemporaryDirectory()
         p = Preferences(directory=self.d.name)
         p.set_preferences({'preset' : True})
-        del p
 
     def test_loadexistingpref(self):
+        """test persistence of preferences file"""
         p = Preferences(directory=self.d.name)
         self.assertTrue(p.get('preset',False))
 

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import warnings
+from pypref import Preferences
+from .fixtures import TemporaryDirectory
+
+
+class TestPreferencesStrings(unittest.TestCase):
+
+    pref = {'string 1' : 'This is a string with interpolation{}',
+            'string 2' : 'With single quote',
+            'string 3' : "With double quote",
+            'string 4' : """Multi-line
+string""" }
+
+
+class Test(unittest.TestCase):
+
+    def setUp(self):
+        self.d = TemporaryDirectory()
+        p = Preferences(directory=self.d.name)
+        p.set_preferences( TestPreferencesStrings.pref )
+
+    def tearDown(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.d = None
+
+    def test_interpolate_string(self):
+        """test string interpolation"""
+        p = Preferences(directory=self.d.name)
+        self.assertEqual(p.get('string 1',"{}").format('!'),
+                         TestPreferencesStrings.pref['string 1'].format('!'))
+
+    def test_various_string_formats(self):
+        """test various string formats"""
+        p = Preferences(directory=self.d.name)
+
+        for key,value in TestPreferencesStrings.pref.items():
+            self.assertEqual(p.get(key,""), value)
+
+if __name__ == '__main__':
+    unittest.main(warnings=None)


### PR DESCRIPTION
Hi @bachiraoun, I pushed this PR to implement support for multi-line strings, for preferences value.

It allows you to save a multi-line string in a preference - feature I'm using to store email templates.

```python
pref = Preferences()
pref.set_preferences({'item 1': """this is a
multi string
value
""" })
```
It comes along with unit testing.

Kindly review and merge.
